### PR TITLE
custom props inside VGridVueTemplate

### DIFF
--- a/public/App.vue
+++ b/public/App.vue
@@ -58,7 +58,9 @@ function generateFakeDataObject(rowsNumber: number, colsNumber: number) {
           if (col === 0) {
             columns[col].rowDrag = true;
             columns[col].editor = 'button';
-            columns[col].cellTemplate = VGridVueTemplate(Cell);
+            columns[col].cellTemplate = VGridVueTemplate(Cell, {
+              temp: 1
+            });
           }
       }
       result[row]['key'] = 'key';

--- a/public/Cell.vue
+++ b/public/Cell.vue
@@ -1,5 +1,5 @@
 <template>
-  <button @click="clickTest">Test {{count}}</button>
+  <button @click="clickTest">Test {{count + ' Custom Props: ' + temp}}</button>
 </template>
 <script lang="ts">
 interface Model {
@@ -11,7 +11,8 @@ export default Vue.extend({
   props: {
     model: {
       type: Object as PropType<Model>
-    }
+    },
+    temp: Number
   },
   computed: {
     count(): number {

--- a/src/vue-template.tsx
+++ b/src/vue-template.tsx
@@ -38,9 +38,10 @@ export const vueTemplateConstructor = (vueConstructor: VueConstructor, e: HTMLEl
 	return vueInstance;
 };
 
-const vueTemplate = (cntr: VueConstructor) => {
+const vueTemplate = (cntr: VueConstructor, customProps?: any) => {
 	return (h: Function, p: any) => {
-		const wrapper = <span ref={(el: HTMLElement) => vueTemplateConstructor(cntr, el, p)}/>;
+		const props = customProps ? {...customProps, ...p} : p
+		const wrapper = <span ref={(el: HTMLElement) => vueTemplateConstructor(cntr, el, props)}/>;
 		return wrapper;
 	};
 };


### PR DESCRIPTION
I need to pass my props in cell templates, but I can't do it. I tried to use eventBus, but I think there must be some way to pass props inside VGridVueTemplate without vue global events.
Example use my solution:
```VGridVueTemplate(Cell, propsObject)```